### PR TITLE
Convert the existing script to class

### DIFF
--- a/mlx/unity2junit/unity2junit.py
+++ b/mlx/unity2junit/unity2junit.py
@@ -12,71 +12,80 @@ import xml.etree.ElementTree as ET
 __version__ = version("mlx-unity2junit")
 
 
-def parse_unity_output(log_file):
-    test_cases = []
-    total_tests = 0
-    failures = 0
-    default_suite_name = "EMPTY"
+class Unity2Junit:
+    """Converts a Unity test output log to a JUnit XML report."""
+    def __init__(self, log_file, output_file):
+        self.log_file = log_file
+        self.output_file = output_file
+        self.test_cases = []
+        self.default_suite_name = "EMPTY"
+        self.total_tests = 0
+        self.failures = 0
 
-    with open(log_file, "r") as f:
-        for line in f:
-            match = re.match(r"(.+):(\d+):(.+):(\w+)", line)
-            if match:
-                file_path, line_number, test_name, result = match.groups()
-                total_tests += 1
+    def parse_unity_output(self):
+        """Parses the Unity log file and populates test case data."""
+        with open(self.log_file, "r") as f:
+            for line in f:
+                match = re.match(r"(.+):(\d+):(.+):(\w+)", line)
+                if match:
+                    file_path, line_number, test_name, result = match.groups()
+                    self.total_tests += 1
 
-                # Extract filename without extension
-                filename = os.path.basename(file_path).replace("utest_", "").split('.')[0].upper()
-                default_suite_name = filename  # Set the default testsuite name
+                    # Extract filename without extension
+                    filename = os.path.basename(file_path).replace("utest_", "").split('.')[0].upper()
+                    self.default_suite_name = filename  # Set the default testsuite name
 
-                # Modify the test name: replace the underscore between SWUTEST_ and the next part with a hyphen
-                formatted_test_name = f"SWUTEST_{filename}-{test_name.upper()}"
+                    # Modify the test name: replace the underscore between SWUTEST_ and the next part with a hyphen
+                    formatted_test_name = f"SWUTEST_{filename}-{test_name.upper()}"
 
-                test_case = {
-                    "name": formatted_test_name,
-                    "classname": f"{filename}.{formatted_test_name}",
-                    "file": file_path.strip(),
-                    "line": line_number.strip(),
-                    "result": result.strip(),
-                    "suite": filename
-                }
-                if result.strip() != "PASS":
-                    failures += 1
-                test_cases.append(test_case)
+                    test_case = {
+                        "name": formatted_test_name,
+                        "classname": f"{filename}.{formatted_test_name}",
+                        "file": file_path.strip(),
+                        "line": line_number.strip(),
+                        "result": result.strip(),
+                        "suite": filename
+                    }
+                    if result.strip() != "PASS":
+                        self.failures += 1
+                    self.test_cases.append(test_case)
 
-    return test_cases, default_suite_name
+    def generate_junit_xml(self):
+        """Generates the JUnit XML report from the parsed test cases."""
+        testsuites = ET.Element("testsuites")
+        timestamp = datetime.now(datetime.timezone.utc).isoformat()
 
+        # Create a default testsuite using extracted filename
+        ET.SubElement(testsuites, "testsuite", name=self.default_suite_name, errors="0", tests="0",
+                      failures="0", skipped="0", timestamp=timestamp)
 
-def generate_junit_xml(test_cases, default_suite_name, output_file):
-    testsuites = ET.Element("testsuites")
-    timestamp = datetime.utcnow().isoformat()
+        for case in self.test_cases:
+            testsuite = ET.SubElement(
+                testsuites, "testsuite",
+                name=case["classname"],
+                timestamp=timestamp,
+                time="0.0",
+                errors="0",
+                tests="1",
+                failures="1" if case["result"] != "PASS" else "0",
+                skipped="0"
+            )
 
-    # Create a default testsuite using extracted filename
-    ET.SubElement(testsuites, "testsuite", name=default_suite_name, errors="0", tests="0",
-                  failures="0", skipped="0", timestamp=timestamp)
+            ET.SubElement(
+                testsuite, "testcase",
+                name=case["name"],
+                classname=case["classname"],
+                time="0.0"
+            )
 
-    for case in test_cases:
-        testsuite = ET.SubElement(
-            testsuites, "testsuite",
-            name=case["classname"],
-            timestamp=timestamp,
-            time="0.0",
-            errors="0",
-            tests="1",
-            failures="1" if case["result"] != "PASS" else "0",
-            skipped="0"
-        )
+        tree = ET.ElementTree(testsuites)
+        tree.write(self.output_file, encoding="utf-8", xml_declaration=True)
+        print(f"JUnit XML report generated: {self.output_file}")
 
-        ET.SubElement(
-            testsuite, "testcase",
-            name=case["name"],
-            classname=case["classname"],
-            time="0.0"
-        )
-
-    tree = ET.ElementTree(testsuites)
-    tree.write(output_file, encoding="utf-8", xml_declaration=True)
-    print(f"JUnit XML report generated: {output_file}")
+    def convert(self):
+        """Runs the conversion from Unity log to JUnit XML."""
+        self.parse_unity_output()
+        self.generate_junit_xml()
 
 
 def main():
@@ -86,8 +95,8 @@ def main():
     parser.add_argument("--version", "-v", action="version", version=f"%(prog)s {__version__}")
     args = parser.parse_args()
 
-    test_cases, default_suite_name = parse_unity_output(args.log_file)
-    generate_junit_xml(test_cases, default_suite_name, args.output_file)
+    converter = Unity2Junit(args.log_file, args.output_file)
+    converter.convert()
 
 
 if __name__ == "__main__":

--- a/tests/unity_parsing_test.py
+++ b/tests/unity_parsing_test.py
@@ -1,31 +1,40 @@
 #!/usr/bin/env python3
 ''' Test suite for functions that set the prefix and prefix_set variables '''
 import unittest
+import tempfile
 from pathlib import Path
 
-from mlx.unity2junit import unity2junit as dut
+from mlx.unity2junit.unity2junit import Unity2Junit
 
 TEST_IN_DIR = Path(__file__).parent / 'test_in'
 
 
 class TestUnityParsing(unittest.TestCase):
+    """Test suite for the Unity log parsing functionality."""
 
     def test_parsing_unity_log_and_building_testcases(self):
-        ''' Use default prefix for unit test reports '''
-        test_cases, default_suite_name = dut.parse_unity_output(TEST_IN_DIR / 'utest_Init_Runner.log')
+        '''Verify that a Unity log file is parsed correctly into test case objects.'''
+        with tempfile.NamedTemporaryFile(mode='w', delete=True) as tmp_output_file:
+            converter = Unity2Junit(TEST_IN_DIR / 'utest_Init_Runner.log', tmp_output_file.name)
+            converter.parse_unity_output()
+            test_cases = converter.test_cases
 
-        for tc in test_cases:
-            # Find some smart way to check the test case class name
-            # self.assertEqual(tc['classname'], 'INIT.SWUTEST_INIT-TEST_INIT_SUCCESS')
-            self.assertEqual(tc['file'], 'unit_test/utest_Init.c')
-            # Find some smart way to check the line number
-            # self.assertEqual(tc['line'], '1')
-            self.assertEqual(tc['result'], 'PASS')
-            # Find some smart way to check for the test name
-            # self.assertEqual(tc['name'], 'SWUTEST_INIT-TEST_INIT_SUCCESS')
-            self.assertEqual(tc['suite'], 'INIT')
+            expected_test_cases_Init_Runner = {}
+            expected_test_cases_Init_Runner['classname'] = ['INIT.SWUTEST_INIT-TEST_INIT_SUCCESS', 'INIT.SWUTEST_INIT-TEST_INIT_WRONG_EEPROM_VERSION', 'INIT.SWUTEST_INIT-TEST_INIT_I2C_READ_FAILS',\
+            'INIT.SWUTEST_INIT-TEST_INIT_I2C_READ_FAILS2','INIT.SWUTEST_INIT-TEST_INIT_I2C_READ_FAILS3']
 
-        self.assertEqual(default_suite_name, 'INIT')
+            for tc in test_cases:
+                # Find some smart way to check the test case class name
+                self.assertEqual(tc['classname'], expected_test_cases_Init_Runner['classname'].pop(0))
+                self.assertEqual(tc['file'], 'unit_test/utest_Init.c')
+                # Find some smart way to check the line number
+                # self.assertEqual(tc['line'], '1')
+                self.assertEqual(tc['result'], 'PASS')
+                # Find some smart way to check for the test name
+                # self.assertEqual(tc['name'], 'SWUTEST_INIT-TEST_INIT_SUCCESS')
+                self.assertEqual(tc['suite'], 'INIT')
+
+            self.assertEqual(converter.default_suite_name, 'INIT')
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     pytest-cov
 commands=
     unity2junit --help
-    {posargs:py.test --cov=mlx --cov-report=term-missing -vv tests/}
+    {posargs:py.test --cov=mlx.unity2junit --cov-report=term-missing -vv tests/}
 
 [testenv:check]
 deps =


### PR DESCRIPTION
Refactor the Unity-to-JUnit conversion logic by encapsulating the parsing and XML generation functionality into a new `Unity2Junit` class, improving maintainability and testability. The test suite is updated to use this new class, and minor improvements are made to the test command configuration.

Also the tox.ini is updated so that coverage is now correctly reported and not missing.

