### PR TITLE
 Fix timezone AttributeError

### DIFF
--- a/mlx/unity2junit/unity2junit.py
+++ b/mlx/unity2junit/unity2junit.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 from importlib.metadata import version
 import os
 import re
@@ -71,7 +71,7 @@ class Unity2Junit:
     def generate_junit_xml(self):
         """Generates the JUnit XML report from the parsed test cases."""
         testsuites = ET.Element("testsuites")
-        timestamp = datetime.now(datetime.timezone.utc).isoformat()
+        timestamp = datetime.now(timezone.utc).isoformat()
 
         # Create a default testsuite using extracted filename
         ET.SubElement(testsuites, "testsuite", name=self.default_suite_name, errors="0", tests=str(self.total_tests),


### PR DESCRIPTION
 When running the script through command line the error:
 ```
 AttributeError: type object 'datetime.datetime' has no attribute 'timezone'. Did you mean: 'astimezone'?
 ```

 To fix this we explicitly include the timezone from datetime.