### PR TITLE
Add failure element to failed test cases

### DIFF
--- a/mlx/unity2junit/unity2junit.py
+++ b/mlx/unity2junit/unity2junit.py
@@ -64,6 +64,8 @@ class Unity2Junit:
                     }
                     if result.strip() == "FAIL":
                         self.failures += 1
+                        if reason:
+                            test_case["reason"] = reason.lstrip(':').strip()
                     elif result.strip() == "SKIP":
                         self.skipped += 1
                     self.test_cases.append(test_case)
@@ -89,12 +91,18 @@ class Unity2Junit:
                 skipped="0"
             )
 
-            ET.SubElement(
+            testcase_element = ET.SubElement(
                 testsuite, "testcase",
                 name=case["name"],
                 classname=case["classname"],
                 time="0.0"
             )
+
+            if case["result"] == "FAIL":
+                message = case.get("reason", "No reason")
+                ET.SubElement(testcase_element, "failure", message=message)
+            elif case["result"] == "SKIP":
+                ET.SubElement(testcase_element, "skipped")
 
         tree = ET.ElementTree(testsuites)
         ET.indent(tree, space="    ", level=0)

--- a/tests/test_in/utest_Failed_Runner.xml
+++ b/tests/test_in/utest_Failed_Runner.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='utf-8'?>
+<testsuites>
+    <testsuite name="INIT" errors="0" tests="5" failures="1" skipped="0" timestamp="2025-09-25T13:40:24.403458+00:00" />
+    <testsuite name="INIT.SWUTEST_INIT-TEST_INIT_SUCCESS" timestamp="2025-09-25T13:40:24.403458+00:00" time="0.0" errors="0" tests="1" failures="0" skipped="0">
+        <testcase name="SWUTEST_INIT-TEST_INIT_SUCCESS" classname="INIT.SWUTEST_INIT-TEST_INIT_SUCCESS" time="0.0" />
+    </testsuite>
+    <testsuite name="INIT.SWUTEST_INIT-TEST_INIT_WRONG_EEPROM_VERSION" timestamp="2025-09-25T13:40:24.403458+00:00" time="0.0" errors="0" tests="1" failures="0" skipped="0">
+        <testcase name="SWUTEST_INIT-TEST_INIT_WRONG_EEPROM_VERSION" classname="INIT.SWUTEST_INIT-TEST_INIT_WRONG_EEPROM_VERSION" time="0.0" />
+    </testsuite>
+    <testsuite name="INIT.SWUTEST_INIT-TEST_INIT_I2C_READ_FAILS" timestamp="2025-09-25T13:40:24.403458+00:00" time="0.0" errors="0" tests="1" failures="1" skipped="0">
+        <testcase name="SWUTEST_INIT-TEST_INIT_I2C_READ_FAILS" classname="INIT.SWUTEST_INIT-TEST_INIT_I2C_READ_FAILS" time="0.0">
+            <failure message="Function Blah_SecondFunction.  Called more times than expected." />
+        </testcase>
+    </testsuite>
+    <testsuite name="INIT.SWUTEST_INIT-TEST_INIT_I2C_READ_FAILS2" timestamp="2025-09-25T13:40:24.403458+00:00" time="0.0" errors="0" tests="1" failures="0" skipped="0">
+        <testcase name="SWUTEST_INIT-TEST_INIT_I2C_READ_FAILS2" classname="INIT.SWUTEST_INIT-TEST_INIT_I2C_READ_FAILS2" time="0.0" />
+    </testsuite>
+    <testsuite name="INIT.SWUTEST_INIT-TEST_INIT_I2C_READ_FAILS3" timestamp="2025-09-25T13:40:24.403458+00:00" time="0.0" errors="0" tests="1" failures="0" skipped="0">
+        <testcase name="SWUTEST_INIT-TEST_INIT_I2C_READ_FAILS3" classname="INIT.SWUTEST_INIT-TEST_INIT_I2C_READ_FAILS3" time="0.0" />
+    </testsuite>
+</testsuites>

--- a/tests/unity_parsing_test.py
+++ b/tests/unity_parsing_test.py
@@ -123,6 +123,26 @@ class TestUnityParsing(unittest.TestCase):
             self.assertEqual(converter.failures, 1)
             self.assertEqual(converter.skipped, 0)
 
+    def test_failed_runner_output(self):
+        '''Verify that utest_Failed_Runner.log is converted to utest_Failed_Runner.xml on a fixed timestamp of
+        2025-09-25T13:40:24.403458+00:00 and that the failure message is correctly included.'''
+        fixed_timestamp_str = "2025-09-25T13:40:24.403458"
+        fixed_datetime = datetime.fromisoformat(fixed_timestamp_str).replace(tzinfo=timezone.utc)
+        expected_xml = ''
+
+        with open(TEST_IN_DIR / 'utest_Failed_Runner.xml', 'r', encoding='utf-8') as f:
+            expected_xml = f.readlines()
+
+        with tempfile.NamedTemporaryFile(mode='w+', delete=True, encoding='utf-8') as tmp_output_file:
+            with patch('mlx.unity2junit.unity2junit.datetime') as mock_dt:
+                mock_dt.now.return_value = fixed_datetime
+                converter = Unity2Junit(TEST_IN_DIR / 'utest_Failed_Runner.log', tmp_output_file.name)
+                converter.convert()
+                tmp_output_file.seek(0)
+                generated_xml = tmp_output_file.readlines()
+                print(generated_xml)
+                self.assertListEqual(generated_xml, expected_xml)
+
     def test_init_runner_output(self):
         '''Verify that utest_Init_Runner.log is converted to utest_Init_Runner.xml on a fixed timestamp of
         2025-09-25T13:40:24.403458+00:00'''

--- a/tests/unity_parsing_test.py
+++ b/tests/unity_parsing_test.py
@@ -140,7 +140,6 @@ class TestUnityParsing(unittest.TestCase):
                 converter.convert()
                 tmp_output_file.seek(0)
                 generated_xml = tmp_output_file.readlines()
-                print(generated_xml)
                 self.assertListEqual(generated_xml, expected_xml)
 
     def test_init_runner_output(self):

--- a/tests/unity_parsing_test.py
+++ b/tests/unity_parsing_test.py
@@ -106,6 +106,9 @@ class TestUnityParsing(unittest.TestCase):
                                                          'SWUTEST_INIT-TEST_INIT_I2C_READ_FAILS2',
                                                          'SWUTEST_INIT-TEST_INIT_I2C_READ_FAILS3']
             expected_test_cases_Failed_Runner['result'] = ['PASS', 'PASS', 'FAIL', 'PASS', 'PASS']
+            expected_test_cases_Failed_Runner['reason'] = [None, None,
+                                                           'Function Blah_SecondFunction.  Called more times than '
+                                                           'expected.', None, None]
 
             for tc in test_cases:
                 # Find some smart way to check the test case class, name and line number
@@ -113,6 +116,9 @@ class TestUnityParsing(unittest.TestCase):
                 self.assertEqual(tc['line'], expected_test_cases_Failed_Runner['line'].pop(0))
                 self.assertEqual(tc['name'], expected_test_cases_Failed_Runner['name'].pop(0))
                 self.assertEqual(tc['result'], expected_test_cases_Failed_Runner['result'].pop(0))
+                expected_reason = expected_test_cases_Failed_Runner['reason'].pop(0)
+                if expected_reason:
+                    self.assertEqual(tc.get('reason'), expected_reason)
 
                 self.assertEqual(tc['file'], 'unit_test/utest_Init.c')
 


### PR DESCRIPTION
Some tools require failure item when test case is failing and do not only rely on the statistics on the top. This adds message element to failure xml element.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Failure reasons are now included in generated JUnit XML failure messages; skipped tests emit dedicated <skipped> elements.

* **Tests**
  * Added end-to-end test and a sample test-results fixture to validate failure-reason handling and skipped-test output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->